### PR TITLE
Add container definition secrets

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,12 @@ const containerDefinitionSchema = {
         '$ref': '/containerEnvironment'
       }
     },
+    'secrets': {
+      'type': 'array',
+      'items': {
+        '$ref': '/containerSecrets'
+      }
+    },
     'disableNetworking': {
       'type': 'boolean'
     },
@@ -228,6 +234,20 @@ const containerEnvironmentSchema = {
       'type': 'string'
     },
     'value': {
+      'type': 'string'
+    },
+  }
+};
+
+const containerSecretsSchema = {
+  'id': '/containerSecrets',
+  'type': 'object',
+  'required': ['name', 'valueFrom'],
+  'properties': {
+    'name': {
+      'type': 'string'
+    },
+    'valueFrom': {
       'type': 'string'
     },
   }
@@ -444,6 +464,7 @@ module.exports = function(taskDefinition, schemaTransformFn) {
     containerPortMappingSchema,
     containerHealthCheckSchema,
     containerEnvironmentSchema,
+    containerSecretsSchema,
     containerExtraHostSchema,
     containerMountPointSchema,
     containerVolumesFromSchema,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecs-task-definition-validator",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -77,12 +77,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -109,14 +109,14 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "jsonschema": {
@@ -130,7 +130,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -179,7 +179,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -193,7 +193,7 @@
       "resolved": "https://registry.npmjs.org/requirize/-/requirize-0.1.3.tgz",
       "integrity": "sha1-cGSYxFRX8Refcm/MNuc1HszmnJ0=",
       "requires": {
-        "underscore.string": "3.3.4"
+        "underscore.string": "^3.3.4"
       }
     },
     "sprintf-js": {
@@ -207,7 +207,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "underscore.string": {
@@ -215,8 +215,8 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
-        "sprintf-js": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecs-task-definition-validator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Validate the an ECS Task Definition",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/valid-task-definition.json
+++ b/test/fixtures/valid-task-definition.json
@@ -14,6 +14,10 @@
       "name": "string",
       "value": "string"
     }],
+    "secrets": [{
+      "name": "string",
+      "valueFrom": "string"
+    }],
     "essential": true,
     "extraHosts": [{
       "hostname": "string",


### PR DESCRIPTION
Newer AWS API has a way to include secrets from SSM directly into environment variables in containers, through the `secrets` field. This was missing in the validator.

NOTE: I did run `npm test`, but I have no idea how to properly test this in an actual environment. I think it's ok, though :).