### PR TITLE
Update volume schema to allow for dockerVolumeConfiguration and efsVolumeConfiguration

### DIFF
--- a/index.js
+++ b/index.js
@@ -419,7 +419,6 @@ const containerLinuxParametersTmpfsSchema = {
 const volume = {
   'id': '/volume',
   'type': 'object',
-  'required': ['name'],
   'properties': {
     'name': {
       'type': 'string'
@@ -427,6 +426,13 @@ const volume = {
     'host': {
       '$ref': '/volumeHost'
     },
+    'dockerVolumeConfiguration': {
+      '$ref': '/volumeDockerVolumeConfiguration'
+
+    },
+    'efsVolumeConfiguration': {
+      '$ref': '/volumeEfsVolumeConfiguration'
+    }
   }
 };
 
@@ -436,6 +442,64 @@ const volumeHostSchema = {
   'properties': {
     'sourcePath': {
       'type': 'string'
+    }
+  }
+};
+
+const volumeDockerVolumeConfigurationSchema = {
+  'id': '/volumeDockerVolumeConfiguration',
+  'type': 'object',
+  'properties': {
+    'scope': {
+      'enum': ['task', 'shared']
+    },
+    'autoprovision': {
+      'type': 'boolean'
+    },
+    'driver': {
+      'type': 'string'
+    },
+    'driverOpts': {
+      'type': 'string'
+    },
+    'labels': {
+      'type': 'string'
+    },
+  }
+};
+
+const volumeEfsVolumeConfigurationSchema = {
+  'id': '/volumeEfsVolumeConfiguration',
+  'type': 'object',
+  'required': ['fileSystemId'],
+  'properties': {
+    'fileSystemId': {
+      'type': 'string'
+    },
+    'rootDirectory': {
+      'type': 'string'
+    },
+    'transitEncryption': {
+      'enum': ['ENABLED', 'DISABLED']
+    },
+    'transitEncryptionPort': {
+      'type': 'integer'
+    },
+    'authorizationConfig': {
+      '$ref': '/volumeEfsVolumeConfigurationAuthorizationConfig'
+    }
+  }
+};
+
+const volumeEfsVolumeConfigurationAuthorizationConfigSchema = {
+  'id': '/volumeEfsVolumeConfigurationAuthorizationConfig',
+  'type': 'object',
+  'properties': {
+    'accessPointId': {
+      'type': 'string'
+    },
+    'iam': {
+      'enum': ['ENABLED', 'DISABLED']
     }
   }
 };
@@ -476,6 +540,9 @@ module.exports = function(taskDefinition, schemaTransformFn) {
     containerLinuxParametersTmpfsSchema,
     volume,
     volumeHostSchema,
+    volumeDockerVolumeConfigurationSchema,
+    volumeEfsVolumeConfigurationSchema,
+    volumeEfsVolumeConfigurationAuthorizationConfigSchema,
     placementConstraintSchema,
   ];
 

--- a/test/fixtures/valid-task-definition.json
+++ b/test/fixtures/valid-task-definition.json
@@ -100,5 +100,28 @@
       "sourcePath": "string"
     },
     "name": "string"
+  },
+  {
+    "name": "string",
+    "dockerVolumeConfiguration": {
+      "scope": "task",
+      "autoprovision": false,
+      "driver": "string",
+      "driverOpts": "string",
+      "labels": "string"
+    }
+  },
+  {
+    "name": "string",
+    "efsVolumeConfiguration": {
+      "fileSystemId": "string",
+      "rootDirectory": "string",
+      "transitEncryption": "ENABLED",
+      "transitEncryptionPort": 1234,
+      "authorizationConfig": {
+        "accessPointId": "string",
+        "iam": "ENABLED"
+      }
+    }
   }]
 }


### PR DESCRIPTION
- Add `dockerVolumeConfiguration` object to `volumes` object
- Add `efsVolumeConfiguration` object and sub-objects to `volumes` object
- Make `name` of `volumes` not required (according to spec)
- Add above objects to valid schema test.